### PR TITLE
add license title

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+ISC License
+
 Copyright (c) 2011 Chris Dary.
 
 Permission to use, copy, modify, and/or distribute this software for any


### PR DESCRIPTION
By the way, the commit message that adds this file says "Adding MIT License", but this is not the [MIT license](http://choosealicense.com/licenses/mit/), it's the [ISC license](http://choosealicense.com/licenses/isc/).
As stated in the second link, "The ISC license is functionally equivalent to the BSD 2-Clause and MIT licenses, removing some language that is no longer necessary." (thanks to the Berne convention covering the additional clauses).